### PR TITLE
optimise existing versions and add a parallelised version

### DIFF
--- a/mojo/mikowals_experiments.mojo
+++ b/mojo/mikowals_experiments.mojo
@@ -71,17 +71,19 @@ fn accelerate(inout particles: VecParticles) -> NoneType:
         particles[idx] = particle
 
     let nb_particules = len(particles)
+
     for i0 in range(nb_particules):
         var p0 = particles[i0]
+
         for i1 in range(i0 + 1, nb_particules):
             var p1 = particles[i1]
             let delta = p0.position - p1.position
             let distance_cube = norm_cube(delta)
             p0.acceleration -= p1.mass / distance_cube * delta
             p1.acceleration += p0.mass / distance_cube * delta
+            particles[i1].acceleration = p1.acceleration
 
-            particles[i0] = p0
-            particles[i1] = p1
+        particles[i0].acceleration = p0.acceleration
 
 
 fn bench[func: fn (inout VecParticles) -> None]() -> Float64:

--- a/mojo/mikowals_experiments.mojo
+++ b/mojo/mikowals_experiments.mojo
@@ -8,7 +8,12 @@ from collections.vector import InlinedFixedVector
 
 import benchmark
 
-from particles import Particles, accelerate_tile, accelerate_vectorize
+from particles import (
+    Particles,
+    accelerate_tile,
+    accelerate_vectorize,
+    accelerate_parallelize_vectorize,
+)
 
 alias Vec4floats = SIMD[DType.float64, 4]
 alias vec4zeros = Vec4floats(0)
@@ -96,7 +101,7 @@ fn bench[func: fn (inout VecParticles) -> None]() -> Float64:
         for i in range(benchmark_iterations):
             func(particles)
 
-    let rep = benchmark.run[wrapper]()
+    let rep = benchmark.run[wrapper](max_runtime_secs=2.0)
     print("Time: ", rep.mean(), "seconds")
 
     return rep.mean()
@@ -110,7 +115,7 @@ fn bench2[func: fn (inout Particles) -> None]() -> Float64:
         for i in range(benchmark_iterations):
             func(particles)
 
-    let rep = benchmark.run[wrapper]()
+    let rep = benchmark.run[wrapper](max_runtime_secs=2.0)
     # using particles to delay its destruction
     let size = particles.size
     print("Time: ", rep.mean(), "seconds")
@@ -182,12 +187,16 @@ fn check_bench_1_nelts[nelts: Int](original_time: Float64):
     print("nelts:", nelts)
     correctness_check[accelerate_vectorize[nelts]]()
     correctness_check[accelerate_tile[nelts]]()
+    correctness_check[accelerate_parallelize_vectorize[nelts]]()
 
     var new_time = bench2[accelerate_vectorize[nelts]]()
     print("Speedup: ", original_time / new_time, " (vectorize)")
 
     new_time = bench2[accelerate_tile[nelts]]()
     print("Speedup: ", original_time / new_time, " (tile)")
+
+    new_time = bench2[accelerate_parallelize_vectorize[nelts]]()
+    print("Speedup: ", original_time / new_time, " (parallelize)")
 
 
 fn main():

--- a/mojo/mikowals_experiments.mojo
+++ b/mojo/mikowals_experiments.mojo
@@ -4,7 +4,7 @@ from algorithm import vectorize, tile
 from memory import memcpy, memset_zero
 from testing import assert_equal, assert_almost_equal
 from sys.info import simdwidthof
-from utils.vector import InlinedFixedVector
+from collections.vector import InlinedFixedVector
 
 import benchmark
 

--- a/mojo/particles.mojo
+++ b/mojo/particles.mojo
@@ -1,7 +1,7 @@
 from math import sqrt
 from random import rand, random_float64
 from algorithm import vectorize, tile
-from memory import memcpy, memset_zero
+from memory import memcpy, memset_zero, stack_allocation
 
 
 fn fill_3D_tuple(n: Int) -> StaticTuple[3, DTypePointer[DType.float64]]:
@@ -84,27 +84,31 @@ fn accelerate_vectorize[nelts: Int](inout particles: Particles):
         memset_zero(acceleration[axis], size)
 
     for i0 in range(size):
+        var acc_0 = StaticTuple[3, DTypePointer[DType.float64]]()
+
+        @unroll
+        for axis in range(3):
+            acc_0[axis] = stack_allocation[nelts, DType.float64]()
+            memset_zero(acc_0[axis], nelts)
 
         @parameter
         fn other_particles[_nelts: Int](i_tail: Int):
             let i1 = i0 + i_tail + 1
-            let delta_x = position[0][i0] - position[0].simd_load[_nelts](i1)
-            let delta_y = position[1][i0] - position[1].simd_load[_nelts](i1)
-            let delta_z = position[2][i0] - position[2].simd_load[_nelts](i1)
-            let distance_cube = norm_cube(delta_x, delta_y, delta_z)
-            let delta = StaticTuple[3, SIMD[DType.float64, _nelts]](
-                delta_x / distance_cube,
-                delta_y / distance_cube,
-                delta_z / distance_cube,
-            )
+            var delta = StaticTuple[3, SIMD[DType.float64, _nelts]]()
 
             @unroll
             for axis in range(3):
+                delta[axis] = position[axis][i0] - position[axis].simd_load[_nelts](i1)
+
+            let distance_cube = norm_cube(delta[0], delta[1], delta[2])
+
+            @unroll
+            for axis in range(3):
+                delta[axis] /= distance_cube
                 let acc_ptr = acceleration[axis]
-                acc_ptr.store(
-                    i0,
-                    acc_ptr[i0]
-                    - (mass.simd_load[_nelts](i1) * delta[axis]).reduce_add(),
+                acc_0[axis].simd_store[_nelts](
+                    acc_0[axis].simd_load[_nelts]()
+                    - (mass.simd_load[_nelts](i1) * delta[axis]),
                 )
 
                 acc_ptr.simd_store[_nelts](
@@ -113,6 +117,10 @@ fn accelerate_vectorize[nelts: Int](inout particles: Particles):
                 )
 
         vectorize[nelts, other_particles](size - i0 - 1)
+
+        @unroll
+        for axis in range(3):
+            acceleration[axis][i0] += acc_0[axis].simd_load[nelts]().reduce_add()
 
 
 fn accelerate_tile[nelts: Int](inout particles: Particles):
@@ -133,26 +141,30 @@ fn accelerate_tile[nelts: Int](inout particles: Particles):
         memset_zero(acceleration[axis], size)
 
     for i0 in range(size):
+        var acc_0 = StaticTuple[3, DTypePointer[DType.float64]]()
+
+        @unroll
+        for axis in range(3):
+            acc_0[axis] = stack_allocation[nelts, DType.float64]()
+            memset_zero(acc_0[axis], nelts)
 
         @parameter
         fn other_particles[_nelts: Int](i1: Int):
-            let delta_x = position[0][i0] - position[0].simd_load[_nelts](i1)
-            let delta_y = position[1][i0] - position[1].simd_load[_nelts](i1)
-            let delta_z = position[2][i0] - position[2].simd_load[_nelts](i1)
-            let distance_cube = norm_cube(delta_x, delta_y, delta_z)
-            let delta = StaticTuple[3, SIMD[DType.float64, _nelts]](
-                delta_x / distance_cube,
-                delta_y / distance_cube,
-                delta_z / distance_cube,
-            )
+            var delta = StaticTuple[3, SIMD[DType.float64, _nelts]]()
 
             @unroll
             for axis in range(3):
+                delta[axis] = position[axis][i0] - position[axis].simd_load[_nelts](i1)
+
+            let distance_cube = norm_cube(delta[0], delta[1], delta[2])
+
+            @unroll
+            for axis in range(3):
+                delta[axis] /= distance_cube
                 let acc_ptr = acceleration[axis]
-                acc_ptr.store(
-                    i0,
-                    acc_ptr[i0]
-                    - (mass.simd_load[_nelts](i1) * delta[axis]).reduce_add(),
+                acc_0[axis].simd_store[_nelts](
+                    acc_0[axis].simd_load[_nelts]()
+                    - (mass.simd_load[_nelts](i1) * delta[axis]),
                 )
 
                 acc_ptr.simd_store[_nelts](
@@ -164,3 +176,7 @@ fn accelerate_tile[nelts: Int](inout particles: Particles):
             other_particles,
             VariadicList[Int](nelts, 1),
         ](i0 + 1, size)
+
+        @unroll
+        for axis in range(3):
+            acceleration[axis][i0] += acc_0[axis].simd_load[nelts]().reduce_add()


### PR DESCRIPTION
I am not sure if you want PRs so feel free to ignore or set aside.  But I got some good speed improvements from small changes so I thought I would share them.

Upgrade to v0.7.0 for items moved from `utils` to `collections`.

simple version improvements
- moving invariant body_i0  to outer loop where I0 is iterated
- using `bodies[i1].accelerate = body_i1.accelerate` triggers `__getitem__`, mutation, `__setitem__` and seems to allow compiler to reason that only one field is changing.  Or maybe there is some cache impact.  But it is much faster.

pointer version improvements
- move invariant outer loop body as in simple version but use a stack_allocated pointer to accumulate changes since we are working with variable SIMD width here.
- minor rewrite of delta_x, delta_y, delta_z with StaticTuple[3, ...] improved speed. 

Added a simple parallelised version that just loops the full set of bodies in both the inner and outer loop and only updates the outer loop body.  I had to zero out the `mass * delta` where the inner and outer iterators are equal though in theory that would be unnecessary because the distance between bodies is already 0.  But without this the correctness checks fail.  Probably floating point noise accumulating over 500 iterations became significant but I am not sure.

Because all versions run in under 0.5 seconds now I set a time limit on the benchmark function of 2 seconds.